### PR TITLE
link to VUE is not working anymore

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -103,14 +103,14 @@
         }
     </style>
 
-    <script src="https://unpkg.com/vue/dist/vue.js"></script>
-    <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+    <script src="https://unpkg.com/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://unpkg.com/vue-i18n@8.27.1/dist/vue-i18n.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.bundle.js"></script>
-    <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+    <script src="https://unpkg.com/vue-i18n@8.27.1/dist/vue-i18n.js"></script>
 
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"


### PR DESCRIPTION
Prevoius link to VUE is not working anymore.
replaced with links to fixed versions (probably used for initial compilation):
vue@2.6.14
vue-i18n@8.27.1

This is workaround but it is working fine. Tested with NodeMCU 3.0, compiled with ArduinoIDE